### PR TITLE
feat: Add SHA verification to install script

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -36,16 +36,20 @@ install_ant() {
       echo "ref installations not currently supported"
       exit 1
   else
-      download="$APACHE_ANT_BASE_URI/apache-ant-${install_version}-bin.tar.gz"
-      # TODO: derive check url for check as well
+      tar_path="$APACHE_ANT_BASE_URI/apache-ant-${install_version}-bin.tar.gz"
+      verify_path="$APACHE_ANT_BASE_URI/apache-ant-${install_version}-bin.tar.gz.sha512"
   fi
 
-  # if [ ! -d "${install_path}/bin" ]; then
-      # mkdir -p "${install_path}/bin"
-  # fi
-
   cd $temp_dir || return 1
-  if ! curl -fLO -# -w "${package_filename}\n" "${download}"; then
+  if ! curl -fLO -# -w "${package_filename}\n" "${tar_path}"; then
+    exit 1
+  fi
+
+  package_sha=$(sha512sum $package_filename | awk '{print $1}')
+  verify_sha=$(curl "${verify_path}")
+
+  if [ $verify_sha != $package_sha ]; then
+    echo "SHA verification failed: $verify_path does not match $package_sha"
     exit 1
   fi
 


### PR DESCRIPTION
Pulls sha512 from distro page to compare against tar

CI running on GitLab since it's better but PR is needed here since GH doesn't do cool things like repo mirroring https://gitlab.com/theoretick/asdf-ant/-/merge_requests/4