### PR TITLE
Update CHANGELOG for 0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.0.2]
 ### Added
 - Changelog
+- Add SHA512 verification (https://gitlab.com/theoretick/asdf-ant/-/merge_requests/4)
+
+### Changed
+- Split `bin/install` and `bin/download` scripts for asdf@0.8+ compatibility (https://gitlab.com/theoretick/asdf-ant/-/merge_requests/8)
 
 ## [0.0.1] - 2020-08-24
 ### Added


### PR DESCRIPTION
- Supports asdf@0.8+
- Add SHA verification
- Splits `bin/install` and `bin/download` scripts